### PR TITLE
Alternative check for isQuantize

### DIFF
--- a/tflite2onnx/op/quantize.py
+++ b/tflite2onnx/op/quantize.py
@@ -26,8 +26,13 @@ class Quantize(Operator):
 
     @property
     def isQuantize(self):
-        assert(self.status.parsed)
-        return self.inputs[0].dtype is TensorProto.FLOAT
+        if self.status.parsed:
+            return self.inputs[0].dtype is TensorProto.FLOAT
+        else:
+            # to cover the case when isQuantize is called from logger
+            # it may happen before the actual parsing begins
+            opcode = self.model.OperatorCodes(self.tflite.OpcodeIndex()).BuiltinCode()
+            return opcode is tflite.BuiltinOperator.QUANTIZE
 
     def parse(self):
         logger.debug("Parsing %s...", self.shorty)


### PR DESCRIPTION
The alternative check is used when a quantize operator has not been parsed.
Instead of using `self.inputs[0].dtype`, which is not available at this point, isQuantize checks the opcode.
Intended to resolve https://github.com/jackwish/tflite2onnx/issues/33